### PR TITLE
control value variable if value is undefined to prevent undefined string

### DIFF
--- a/src/Datepicker/Datepicker.tsx
+++ b/src/Datepicker/Datepicker.tsx
@@ -17,7 +17,7 @@ type DatepickerType = {
 };
 
 function getDateValues(value: string) {
-    if (value !== null && value[0] !== null) {
+    if (value && value !== null && value[0] !== null) {
         const [year, month, day] = value.split("-");
         return {
             day: day,
@@ -71,7 +71,7 @@ export function Datepicker({
         year: getDateValues(value).year,
     });
     useEffect(() => {
-        if (value !== null && value !== "--") {
+        if (value && value !== null && value !== "--") {
             setDateValues(getDateValues(value));
         }
     }, [value]);


### PR DESCRIPTION
There was an bug where if the value of the datepicker was undefined it parsed a string "undefined" and injected it into the component. 