### PR TITLE
Fix: QuestionExplication closes when changing pages

### DIFF
--- a/src/QuestionExplication.tsx
+++ b/src/QuestionExplication.tsx
@@ -1,6 +1,6 @@
 import { useColors } from "@codegouvfr/react-dsfr/useColors";
 import { themeStringToVariable } from "./utils/themeStringToVariable";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { fr } from "@codegouvfr/react-dsfr";
 
 type QuestionExplicationType = {
@@ -11,17 +11,16 @@ type QuestionExplicationType = {
 
 export function QuestionExplication({ label, description, bgColor }: QuestionExplicationType) {
     const theme = useColors();
-    const [expanded, setExpanded] = useState<boolean>(false);
 
-    useEffect(() => {
-        if (expanded === true) {
-            setExpanded(false);
-        }
-    }, [label]);
+    const [expandedDescription, setExpandedDescription] = useState<string | null>(null);
 
     const handleExpandedChange = useCallback(() => {
-        setExpanded(expanded => !expanded);
-    }, [expanded]);
+        // toggle expandedDescription between null and current description
+        setExpandedDescription(v => (v === description ? null : description));
+    }, [description]);
+
+    // accordion expands if expandedDescription corresponds to current description
+    const isExpanded = expandedDescription === description;
 
     const backgroundColor = themeStringToVariable(
         theme,
@@ -41,7 +40,7 @@ export function QuestionExplication({ label, description, bgColor }: QuestionExp
                     <h3 className={fr.cx("fr-accordion__title")}>
                         <button
                             className={fr.cx("fr-accordion__btn")}
-                            aria-expanded={expanded}
+                            aria-expanded={isExpanded}
                             aria-controls="accordion-106"
                             onClick={handleExpandedChange}
                         >

--- a/src/QuestionExplication.tsx
+++ b/src/QuestionExplication.tsx
@@ -1,6 +1,7 @@
-import { Accordion as AccordionDSFR } from "@codegouvfr/react-dsfr/Accordion";
 import { useColors } from "@codegouvfr/react-dsfr/useColors";
 import { themeStringToVariable } from "./utils/themeStringToVariable";
+import { useCallback, useEffect, useState } from "react";
+import { fr } from "@codegouvfr/react-dsfr";
 
 type QuestionExplicationType = {
     label: string;
@@ -10,6 +11,18 @@ type QuestionExplicationType = {
 
 export function QuestionExplication({ label, description, bgColor }: QuestionExplicationType) {
     const theme = useColors();
+    const [expanded, setExpanded] = useState<boolean>(false);
+
+    useEffect(() => {
+        if (expanded === true) {
+            setExpanded(false);
+        }
+    }, [label]);
+
+    const handleExpandedChange = useCallback(() => {
+        setExpanded(!expanded);
+    }, [label, expanded]);
+
     const backgroundColor = themeStringToVariable(
         theme,
         bgColor,
@@ -24,9 +37,21 @@ export function QuestionExplication({ label, description, bgColor }: QuestionExp
             className="fr-py-2w"
         >
             <div className={"fr-container fr-grid-row fr-grid-row--center fr-grid-row--middle fr-px-1w"}>
-                <AccordionDSFR label={label} className={"fr-col-lg-6 fr-col-md-9 fr-col-12"}>
-                    {description}
-                </AccordionDSFR>
+                <section className={fr.cx("fr-accordion", "fr-col-lg-6", "fr-col-md-9", "fr-col-12")}>
+                    <h3 className={fr.cx("fr-accordion__title")}>
+                        <button
+                            className={fr.cx("fr-accordion__btn")}
+                            aria-expanded={expanded}
+                            aria-controls="accordion-106"
+                            onClick={handleExpandedChange}
+                        >
+                            {label}
+                        </button>
+                    </h3>
+                    <div className={fr.cx("fr-collapse")} id="accordion-106">
+                        {description}
+                    </div>
+                </section>
             </div>
         </div>
     );

--- a/src/QuestionExplication.tsx
+++ b/src/QuestionExplication.tsx
@@ -20,8 +20,8 @@ export function QuestionExplication({ label, description, bgColor }: QuestionExp
     }, [label]);
 
     const handleExpandedChange = useCallback(() => {
-        setExpanded(!expanded);
-    }, [label, expanded]);
+        setExpanded(expanded => !expanded);
+    }, [expanded]);
 
     const backgroundColor = themeStringToVariable(
         theme,

--- a/src/stories/question-explication/source.json
+++ b/src/stories/question-explication/source.json
@@ -1,14 +1,30 @@
 {
+    "maxPage": "3",
     "components": [
         {
+            "page": "1",
             "id": "question-explication",
             "componentType": "QuestionExplication",
             "label": {
-                "value": "\"QuestionExplication label\"",
+                "value": "\"QuestionExplication label 1\"",
                 "type": "VTL"
             },
             "description": {
-                "value": "\"QuestionExplication content\"",
+                "value": "\"QuestionExplication content 1\"",
+                "type": "VTL"
+            },
+            "bgColor": "purpleGlycine.default"
+        },
+        {
+            "page": "2",
+            "id": "question-explication",
+            "componentType": "QuestionExplication",
+            "label": {
+                "value": "\"QuestionExplication label 2\"",
+                "type": "VTL"
+            },
+            "description": {
+                "value": "\"QuestionExplication content 2\"",
                 "type": "VTL"
             },
             "bgColor": "purpleGlycine.default"


### PR DESCRIPTION
If user opens a QuestionExplication and there is another QuestionExplication on page n+1, the QuestionExplication on page n+1 is open as well, whereas it should be closed on page change. 

Solution: 
Control the expanded props so that the expanded is false whenever the component changes. 