### PR TITLE
fix-combobox-panel-container

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inseefr/lunatic-dsfr",
-    "version": "0.0.35",
+    "version": "0.0.36",
     "description": "Couche graphique pour Lunatic reposant sur le Système de Design de l'État (DSFR)",
     "repository": {
         "type": "git",

--- a/src/Datepicker/DatepickerInput.tsx
+++ b/src/Datepicker/DatepickerInput.tsx
@@ -101,7 +101,7 @@ export function DatepickerInput({
                 <InputDSFR
                     disabled={disabled}
                     label="Mois"
-                    hintText="Exemple: 7"
+                    hintText="Exemple: 07"
                     className={state ? `fr-input-group--${state}` : ""}
                     nativeInputProps={{
                         id: `${id}-month`,

--- a/src/Suggester/elements/ComboBoxPanelContainer.tsx
+++ b/src/Suggester/elements/ComboBoxPanelContainer.tsx
@@ -11,7 +11,8 @@ type Props = PropsWithChildren<{
 const useStyles = makeStyles()(theme => ({
     root: {
         maxHeight: "20rem",
-        overflow: "scroll",
+        overflowX: "hidden",
+        overflowY: "scroll",
         "> li": {
             listStyle: "none",
             boxSizing: "border-box",
@@ -34,25 +35,29 @@ const useStyles = makeStyles()(theme => ({
 
 export function ComboboxPanelContainer({ children, focused, expanded, id }: Props) {
     const { classes, cx } = useStyles();
-    return (
-        <ul
-            id={`lunatic-combo-box-panel-${id}`}
-            aria-label="suggestions"
-            className={classnames(
-                "lunatic-combo-box-panel",
-                "fr-select",
-                "fr-p-0",
-                "fr-mb-0",
-                "fr-mt-0",
-                {
-                    focused,
-                    expanded,
-                },
-                cx(classes.root),
-            )}
-            role="listbox"
-        >
-            {children}
-        </ul>
-    );
+
+    if (Array.isArray(children) && children.length > 0) {
+        return (
+            <ul
+                id={`lunatic-combo-box-panel-${id}`}
+                aria-label="suggestions"
+                className={classnames(
+                    "lunatic-combo-box-panel",
+                    "fr-select",
+                    "fr-p-0",
+                    "fr-mb-0",
+                    "fr-mt-0",
+                    {
+                        focused,
+                        expanded,
+                    },
+                    cx(classes.root),
+                )}
+                role="listbox"
+            >
+                {children}
+            </ul>
+        );
+    }
+    return null;
 }

--- a/src/stories/modal/modal.stories.jsx
+++ b/src/stories/modal/modal.stories.jsx
@@ -4,9 +4,6 @@ import Orchestrator from "../utils/Orchestrator";
 import source from "./source.json";
 import * as custom from "../..";
 
-// eslint-disable-next-line no-undef
-console.log(custom);
-
 const stories = {
     title: "Components/Modal",
     component: Orchestrator,


### PR DESCRIPTION
If there is no children in the suggester (aka : the user hasn't search for anything), we don't want to display the ```<ul>```

I am also fixing the style of the ComboboxPanelContainer to remove the scrollbar. 