### PR TITLE
fix: modal behaviour

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -3,7 +3,7 @@ import { createPortal } from "react-dom";
 import { Button } from "./Button";
 import { type LunaticComponentProps } from "./type";
 import { fr } from "@codegouvfr/react-dsfr";
-import classnames from "classnames";
+import { useStyles } from "tss-react/dsfr";
 
 type Props = Pick<LunaticComponentProps<"Modal">, "id" | "label" | "description"> & {
     onClose: ReactEventHandler<HTMLDialogElement>;
@@ -14,75 +14,65 @@ type Props = Pick<LunaticComponentProps<"Modal">, "id" | "label" | "description"
 
 export function Modal(props: Props) {
     const { id, label, description, onClose, onCancel, onClick, dialogRef } = props;
-
+    const { css } = useStyles();
     return createPortal(
         <dialog
-            className={classnames("lunatic-dsfr-modal", fr.cx("fr-modal", "fr-modal--opened"))}
             ref={dialogRef}
             id={id}
             onClose={onClose}
             onCancel={onCancel}
             onClick={onClick}
+            className={css({
+                padding: 0,
+                border: "none",
+                boxShadow: "none",
+                overflow: "hidden",
+                maxWidth: 600,
+            })}
         >
-            <div className={fr.cx("fr-container", "fr-container--fluid", "fr-container-md")}>
-                <div className={fr.cx("fr-grid-row", "fr-grid-row--center")}>
-                    <div className={fr.cx("fr-col-12", "fr-col-md-8", "fr-col-lg-6")}>
-                        <form method="dialog" className={fr.cx("fr-modal__body")}>
-                            <div className={fr.cx("fr-modal__header")}>
-                                <Button
-                                    className={fr.cx("fr-btn--close")}
-                                    disabled={false}
-                                    type="submit"
-                                    value="cancel"
-                                    priority={"tertiary no outline"}
-                                >
-                                    Fermer
-                                </Button>
-                            </div>
-                            <div className={fr.cx("fr-modal__content")}>
-                                <h1 id={`${id}-title`} className={fr.cx("fr-modal__title")}>
-                                    {/* Label is defined in the source.json, and we can accept VTL|MD or VTL */}
-                                    {label}
-                                </h1>
-                                {/* Label is defined in the source.json, and we can accept VTL|MD or VTL */}
-                                <p>{description}</p>
-                            </div>
-                            <div className={fr.cx("fr-modal__footer")}>
-                                <ul
-                                    className={fr.cx(
-                                        "fr-btns-group",
-                                        "fr-btns-group--right",
-                                        "fr-btns-group--inline-reverse",
-                                        "fr-btns-group--inline-lg",
-                                        "fr-btns-group--icon-left",
-                                    )}
-                                >
-                                    <li>
-                                        <Button
-                                            value="default"
-                                            disabled={false}
-                                            type="submit"
-                                            priority={"primary"}
-                                        >
-                                            Je confirme
-                                        </Button>
-                                    </li>
-                                    <li>
-                                        <Button
-                                            value="cancel"
-                                            disabled={false}
-                                            type="submit"
-                                            priority={"secondary"}
-                                        >
-                                            Annuler
-                                        </Button>
-                                    </li>
-                                </ul>
-                            </div>
-                        </form>
-                    </div>
+            <form method="dialog" className={fr.cx("fr-modal__body")}>
+                <div className={fr.cx("fr-modal__header")}>
+                    <Button
+                        className={fr.cx("fr-btn--close")}
+                        disabled={false}
+                        type="submit"
+                        value="cancel"
+                        priority={"tertiary no outline"}
+                    >
+                        Fermer
+                    </Button>
                 </div>
-            </div>
+                <div className={fr.cx("fr-modal__content")}>
+                    <h1 id={`${id}-title`} className={fr.cx("fr-modal__title")}>
+                        {/* Label is defined in the source.json, and we can accept VTL|MD or VTL */}
+                        {label}
+                    </h1>
+                    {/* Label is defined in the source.json, and we can accept VTL|MD or VTL */}
+                    <p>{description}</p>
+                </div>
+                <div className={fr.cx("fr-modal__footer")}>
+                    <ul
+                        className={fr.cx(
+                            "fr-btns-group",
+                            "fr-btns-group--right",
+                            "fr-btns-group--inline-reverse",
+                            "fr-btns-group--inline-lg",
+                            "fr-btns-group--icon-left",
+                        )}
+                    >
+                        <li>
+                            <Button value="default" disabled={false} type="submit" priority={"primary"}>
+                                Je confirme
+                            </Button>
+                        </li>
+                        <li>
+                            <Button value="cancel" disabled={false} type="submit" priority={"secondary"}>
+                                Annuler
+                            </Button>
+                        </li>
+                    </ul>
+                </div>
+            </form>
         </dialog>,
         document.body,
     );


### PR DESCRIPTION
On dirait qu'il y a du JS global qui venait ajouter une logique par dessus la dialog classique qui s'appelle "fr-modal". Si vous choisiseez de ne pas utiliser le DSFR alors il ne faut pas greffer les comportements.

Voici une capture de la correction : 
![image](https://github.com/InseeFr/Lunatic-DSFR/assets/395137/0b00d5ef-27be-46ef-a249-ebc44ecab948)


Je vous laisse rajouter le style pour le backdrop (via le selecteur CSS ::backdrop)