### PR TITLE
feat: use real datepicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,8 @@
         "vitest": "^2.0.5"
     },
     "dependencies": {
+        "@mui/x-date-pickers": "^7.28.0",
+        "date-fns": "^4.1.0",
         "react-number-format": "^5.4.0"
     },
     "publishConfig": {

--- a/src/Datepicker.spec.tsx
+++ b/src/Datepicker.spec.tsx
@@ -1,15 +1,6 @@
 import { render, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
-import { Datepicker } from "./Datepicker"; // Assuming your Datepicker component is in this file
-
-vi.mock("./shared/CustomInputDsfr", () => ({
-    CustomInputDsfr: vi.fn(({ value, onChange, dsfrProps, id }) => (
-        <div>
-            <label htmlFor={id}>{dsfrProps?.label}</label>
-            <input id={id} value={value} onChange={onChange} data-testid="custom-input" />
-        </div>
-    )),
-}));
+import { DateFormat, Datepicker } from "./Datepicker";
 
 describe("Datepicker Component", () => {
     const onChangeMock = vi.fn();
@@ -20,96 +11,74 @@ describe("Datepicker Component", () => {
         onChange: onChangeMock,
     };
 
-    it("renders the Datepicker fields correctly for format YYYY-MM-DD", () => {
-        const { getByLabelText } = render(<Datepicker {...defaultProps} dateFormat={"YYYY-MM-DD"} />);
-
-        // Check that the input fields for day, month, and year are rendered
-        expect(getByLabelText("Année")).toBeInTheDocument();
-        expect(getByLabelText("Mois")).toBeInTheDocument();
-        expect(getByLabelText("Jour")).toBeInTheDocument();
+    beforeEach(() => {
+        onChangeMock.mockClear();
     });
 
-    it("renders the Datepicker fields correctly for format YYYY-MM", () => {
-        const { getByLabelText, queryByLabelText } = render(
-            <Datepicker {...defaultProps} dateFormat={"YYYY-MM"} />,
-        );
+    const dateFormats: DateFormat[] = ["YYYY-MM-DD", "YYYY-MM", "YYYY"];
 
-        // Check that the only input fields for month, and year are rendered
-        expect(getByLabelText("Année")).toBeInTheDocument();
-        expect(getByLabelText("Mois")).toBeInTheDocument();
+    dateFormats.forEach(format => {
+        it(`should render properly with format ${format}`, () => {
+            const { getByRole } = render(<Datepicker {...defaultProps} dateFormat={format} />);
 
-        expect(queryByLabelText("Jour")).not.toBeInTheDocument();
-    });
-
-    it("renders the Datepicker fields correctly for format YYYY", () => {
-        const { getByLabelText, queryByLabelText } = render(
-            <Datepicker {...defaultProps} dateFormat={"YYYY"} />,
-        );
-
-        // Check that only the input field for year is rendered
-        expect(getByLabelText("Année")).toBeInTheDocument();
-
-        expect(queryByLabelText("Mois")).not.toBeInTheDocument();
-        expect(queryByLabelText("Jour")).not.toBeInTheDocument();
+            const input = getByRole("textbox");
+            expect(input).toBeInTheDocument();
+        });
     });
 
     it("handle change correctly for format YYYY-MM-DD", () => {
-        const { getByLabelText } = render(<Datepicker {...defaultProps} dateFormat="YYYY-MM-DD" />);
+        const { getByRole } = render(<Datepicker {...defaultProps} dateFormat="YYYY-MM-DD" />);
 
-        const yearInput = getByLabelText("Année");
-        const monthInput = getByLabelText("Mois");
-        const dayInput = getByLabelText("Jour");
+        const input = getByRole("textbox");
 
         // handle valid dates
-        fireEvent.change(yearInput, { target: { value: "2025" } });
-        expect(onChangeMock).toHaveBeenCalledWith("2025-01-01");
-        fireEvent.change(monthInput, { target: { value: "02" } });
-        expect(onChangeMock).toHaveBeenCalledWith("2025-02-01");
-        fireEvent.change(dayInput, { target: { value: "05" } });
+        fireEvent.change(input, { target: { value: "05/02/2025" } });
         expect(onChangeMock).toHaveBeenCalledWith("2025-02-05");
 
-        // handle invalid date. Ex : 2025-02-30
-        fireEvent.change(dayInput, { target: { value: "30" } });
+        // handle invalid dates
+        fireEvent.change(input, { target: { value: "29/02/2025" } });
         expect(onChangeMock).toHaveBeenCalledWith(null);
 
         // handle year with less than 4 digits, and month/day with 1 digit
-        fireEvent.change(yearInput, { target: { value: "25" } });
-        fireEvent.change(monthInput, { target: { value: "5" } });
-        fireEvent.change(dayInput, { target: { value: "8" } });
+        fireEvent.change(input, { target: { value: "8/5/25" } });
         expect(onChangeMock).toHaveBeenCalledWith("0025-05-08");
     });
 
     it("handle change correctly for format YYYY-MM", () => {
-        const { getByLabelText } = render(
+        const { getByRole } = render(
             <Datepicker {...defaultProps} dateFormat="YYYY-MM" value="2024-01" />,
         );
 
-        const yearInput = getByLabelText("Année");
-        const monthInput = getByLabelText("Mois");
+        const input = getByRole("textbox");
 
-        fireEvent.change(yearInput, { target: { value: "2025" } });
-        expect(onChangeMock).toHaveBeenCalledWith("2025-01");
-        fireEvent.change(monthInput, { target: { value: "02" } });
+        fireEvent.change(input, { target: { value: "02/2025" } });
         expect(onChangeMock).toHaveBeenCalledWith("2025-02");
 
         // handle year with less than 4 digits, and month with 1 digit
-        fireEvent.change(yearInput, { target: { value: "25" } });
-        fireEvent.change(monthInput, { target: { value: "5" } });
+        fireEvent.change(input, { target: { value: "5/25" } });
         expect(onChangeMock).toHaveBeenCalledWith("0025-05");
     });
 
     it("handle change correctly for format YYYY", () => {
-        const { getByLabelText } = render(
-            <Datepicker {...defaultProps} dateFormat="YYYY" value="2024" />,
-        );
+        const { getByRole } = render(<Datepicker {...defaultProps} dateFormat="YYYY" value="2024" />);
 
-        const yearInput = getByLabelText("Année");
+        const input = getByRole("textbox");
 
-        fireEvent.change(yearInput, { target: { value: "2025" } });
+        fireEvent.change(input, { target: { value: "2025" } });
         expect(onChangeMock).toHaveBeenCalledWith("2025");
 
         // handle year with less than 4 digits
-        fireEvent.change(yearInput, { target: { value: "25" } });
+        fireEvent.change(input, { target: { value: "25" } });
         expect(onChangeMock).toHaveBeenCalledWith("0025");
+    });
+
+    it("handle change correctly clicking the clear button", () => {
+        const { getByRole } = render(<Datepicker {...defaultProps} dateFormat="YYYY-MM-DD" />);
+
+        // Click on the clear button
+        const clearButton = getByRole("button", { name: "Effacer la valeur" });
+        fireEvent.click(clearButton);
+
+        expect(onChangeMock).toHaveBeenCalledWith(null);
     });
 });

--- a/src/Datepicker.tsx
+++ b/src/Datepicker.tsx
@@ -9,6 +9,7 @@ import { parseISO, format } from "date-fns";
 import type { LunaticSlotComponents } from "@inseefr/lunatic";
 import { useQuestionId } from "./Question";
 import { frFR } from "@mui/x-date-pickers/locales";
+import type { DateView } from "@mui/x-date-pickers";
 
 export type DateFormat = "YYYY-MM-DD" | "YYYY-MM" | "YYYY";
 
@@ -84,6 +85,7 @@ export const Datepicker: LunaticSlotComponents["Datepicker"] = props => {
                     value={selectedDate}
                     onChange={handleDateChange}
                     format={computeDisplayedFormat(dateFormat)}
+                    views={computeViews(dateFormat)}
                     minDate={minDate}
                     maxDate={maxDate}
                     disabled={disabled}
@@ -139,4 +141,16 @@ function computeDisplayedFormat(format: DateFormat) {
 /** Compute date-fns format */
 function computeDateFnsFormat(format: DateFormat) {
     return format.replace("YYYY", "yyyy").replace("DD", "dd");
+}
+
+/** Compute views for calendar */
+function computeViews(format: DateFormat): DateView[] {
+    switch (format) {
+        case "YYYY":
+            return ["year"];
+        case "YYYY-MM":
+            return ["month", "year"];
+        default:
+            return ["year", "month", "day"];
+    }
 }

--- a/src/Datepicker.tsx
+++ b/src/Datepicker.tsx
@@ -7,7 +7,6 @@ import { fr } from "@codegouvfr/react-dsfr";
 import { fr as frLocale } from "date-fns/locale/fr";
 import { parseISO, format } from "date-fns";
 import type { LunaticSlotComponents } from "@inseefr/lunatic";
-import { FiledsetError } from "./shared/FieldsetError";
 import { useQuestionId } from "./Question";
 import { frFR } from "@mui/x-date-pickers/locales";
 
@@ -30,7 +29,6 @@ export const Datepicker: LunaticSlotComponents["Datepicker"] = props => {
 
     const id = useId();
     const questionId = useQuestionId();
-    const errorMessageId = `${id}-messages`;
 
     if (declarations) {
         console.error("Only declaration in Question are displayed");
@@ -51,58 +49,78 @@ export const Datepicker: LunaticSlotComponents["Datepicker"] = props => {
     };
 
     const { state, stateRelatedMessage } = getErrorStates(errors);
-    const hasLegend = Boolean(label || description);
+    const hasLabel = Boolean(label || description);
+    const labelId = `label-${id}`;
 
     return (
-        <fieldset
+        <div
             className={fr.cx(
-                "fr-fieldset",
+                "fr-input-group",
                 (() => {
                     switch (state) {
+                        case "error":
+                            return "fr-input-group--error";
+                        case "success":
+                            return "fr-input-group--valid";
                         case "default":
                             return undefined;
-                        case "error":
-                            return "fr-fieldset--error";
-                        case "success":
-                            return "fr-fieldset--valid";
                     }
                 })(),
             )}
-            id={`${id}-fieldset`}
-            aria-labelledby={label ? undefined : questionId}
         >
-            {hasLegend && (
-                <legend className={fr.cx("fr-fieldset__legend")}>
+            {hasLabel && (
+                <label className={fr.cx("fr-label")} htmlFor={id} id={`label-${id}`}>
+                    {label}
                     {description && <span className={fr.cx("fr-hint-text")}>{description}</span>}
-                </legend>
+                </label>
             )}
 
-            <div className={fr.cx("fr-fieldset__element", "fr-fieldset__element--inline")}>
-                {/* Cannot give the className directly to MuiDatePicker since mui style overloads it. */}
-                <LocalizationProvider
-                    dateAdapter={AdapterDateFns}
-                    adapterLocale={frLocale}
-                    localeText={frFR.components.MuiLocalizationProvider.defaultProps.localeText}
-                >
-                    <MuiDatePicker
-                        value={selectedDate}
-                        onChange={handleDateChange}
-                        format={computeDisplayedFormat(dateFormat)}
-                        minDate={minDate}
-                        maxDate={maxDate}
-                        disabled={disabled}
-                        readOnly={readOnly}
-                        slotProps={{
-                            field: {
-                                clearable: true,
-                            },
-                        }}
-                    />
-                </LocalizationProvider>
-            </div>
+            <LocalizationProvider
+                dateAdapter={AdapterDateFns}
+                adapterLocale={frLocale}
+                localeText={frFR.components.MuiLocalizationProvider.defaultProps.localeText}
+            >
+                <MuiDatePicker
+                    value={selectedDate}
+                    onChange={handleDateChange}
+                    format={computeDisplayedFormat(dateFormat)}
+                    minDate={minDate}
+                    maxDate={maxDate}
+                    disabled={disabled}
+                    readOnly={readOnly}
+                    slotProps={{
+                        field: {
+                            clearable: true,
+                        },
+                        textField: {
+                            id,
+                            "aria-labelledby": hasLabel ? labelId : questionId,
+                        },
+                    }}
+                />
+            </LocalizationProvider>
 
-            <FiledsetError state={state} stateRelatedMessage={stateRelatedMessage} id={errorMessageId} />
-        </fieldset>
+            {state && stateRelatedMessage && (
+                <div id={`${id}-messages-group`} className={fr.cx("fr-messages-group")} role="alert">
+                    <p
+                        id={`${id}-${state}`}
+                        className={fr.cx(
+                            "fr-message",
+                            (() => {
+                                switch (state) {
+                                    case "error":
+                                        return "fr-message--error";
+                                    case "success":
+                                        return "fr-message--valid";
+                                }
+                            })(),
+                        )}
+                    >
+                        {stateRelatedMessage}
+                    </p>
+                </div>
+            )}
+        </div>
     );
 };
 

--- a/src/Datepicker.tsx
+++ b/src/Datepicker.tsx
@@ -1,14 +1,17 @@
 import { useId, useState } from "react";
 import { getErrorStates } from "./utils/errorStates";
+import { DatePicker as MuiDatePicker } from "@mui/x-date-pickers/DatePicker";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFnsV3";
 import { fr } from "@codegouvfr/react-dsfr";
+import { fr as frLocale } from "date-fns/locale/fr";
+import { parseISO, format } from "date-fns";
 import type { LunaticSlotComponents } from "@inseefr/lunatic";
-import type { Split } from "./utils/type";
-import { NumericFormat, type NumberFormatValues } from "react-number-format";
 import { FiledsetError } from "./shared/FieldsetError";
-import { CustomInputDsfr } from "./shared/CustomInputDsfr";
 import { useQuestionId } from "./Question";
+import { frFR } from "@mui/x-date-pickers/locales";
 
-type DateState = { day: string; month: string; year: string };
+export type DateFormat = "YYYY-MM-DD" | "YYYY-MM" | "YYYY";
 
 export const Datepicker: LunaticSlotComponents["Datepicker"] = props => {
     const {
@@ -16,78 +19,35 @@ export const Datepicker: LunaticSlotComponents["Datepicker"] = props => {
         readOnly,
         value = "",
         dateFormat = "YYYY-MM-DD",
+        min,
+        max,
         label,
         errors,
         description,
         declarations,
         onChange,
-        iteration,
     } = props;
 
     const id = useId();
     const questionId = useQuestionId();
-
     const errorMessageId = `${id}-messages`;
 
     if (declarations) {
-        //TODO throw and handle globaly errors in an alert with a condition to avoid to display alert in prod
         console.error("Only declaration in Question are displayed");
     }
 
-    const showDay = dateFormat.includes("DD");
-    const showMonth = dateFormat.includes("MM");
+    // Convert value string to Date object
+    const parsedDate = value ? parseISO(value) : null;
+    const [selectedDate, setSelectedDate] = useState<Date | null>(parsedDate);
 
-    const extractDateFromValue = () => {
-        if (!value) {
-            return { year: "", month: "", day: "" };
-        }
-        const parts = value.split("-");
+    // Convert min/max props to Date objects
+    const minDate = min ? parseISO(min) : undefined;
+    const maxDate = max ? parseISO(max) : undefined;
 
-        return {
-            year: parts[0] ?? "",
-            month: parts[1] ?? "",
-            day: parts[2] ?? "",
-        };
-    };
-    const [dateValues, setDateValues] = useState<DateState>(extractDateFromValue);
-
-    const onValueChange = (values: NumberFormatValues, key: keyof DateState) => {
-        updateDate(key, values.value);
-    };
-
-    const updateDate = (key: keyof DateState, value: string) => {
-        const newDate = {
-            ...dateValues,
-            [key]: value,
-        };
-        setDateValues(newDate);
-        onDateChange(newDate);
-    };
-
-    const onDateChange = (date: DateState) => {
-        const formatParts = dateFormat.split("-") as Split<"YYYY-MM-DD" | "YYYY-MM" | "YYYY", "-">;
-        const countEmptyDate = Object.values(date).filter(d => d === "").length;
-
-        // Date has a missing part
-        if (countEmptyDate > 3 - formatParts.length) {
-            onChange(null);
-            return;
-        }
-
-        // Date is not valid
-        if (dateFormat === "YYYY-MM-DD" && !isDateValid(date)) {
-            onChange(null);
-            return;
-        }
-
-        const mapping = {
-            "YYYY": date.year.padStart(4, "0"),
-            "MM": date.month.padStart(2, "0"),
-            "DD": date.day.padStart(2, "0"),
-        };
-
-        const result = formatParts.map(part => mapping[part]).join("-");
-        onChange(result);
+    const handleDateChange = (date: Date | null) => {
+        setSelectedDate(date);
+        // Convert the date back to the string format expected by the component
+        onChange(date ? format(date, computeDateFnsFormat(dateFormat)) : null);
     };
 
     const { state, stateRelatedMessage } = getErrorStates(errors);
@@ -113,107 +73,32 @@ export const Datepicker: LunaticSlotComponents["Datepicker"] = props => {
         >
             {hasLegend && (
                 <legend className={fr.cx("fr-fieldset__legend")}>
-                    {label}
                     {description && <span className={fr.cx("fr-hint-text")}>{description}</span>}
                 </legend>
             )}
-            {showDay && (
-                <div
-                    className={fr.cx(
-                        "fr-fieldset__element",
-                        "fr-fieldset__element--inline",
-                        "fr-fieldset__element--number",
-                    )}
-                >
-                    <NumericFormat
-                        id={`${id}-day-${iteration ?? ""}`}
-                        key={`${id}-${iteration ?? ""}-day`}
-                        customInput={CustomInputDsfr}
-                        disabled={disabled}
-                        readOnly={readOnly}
-                        allowNegative={false}
-                        inputMode="numeric"
-                        dsfrProps={{
-                            label: "Jour",
-                            hintText: "Exemple: 14",
-                        }}
-                        allowLeadingZeros
-                        isAllowed={({ value, floatValue }) =>
-                            floatValue === undefined ||
-                            (floatValue >= 0 && value.length <= 2 && value !== "00" && floatValue <= 31)
-                        }
-                        onValueChange={values => onValueChange(values, "day")}
-                        value={dateValues.day}
-                        {...(state === "error"
-                            ? { "aria-invalid": true, "aria-errormessage": errorMessageId }
-                            : {})}
-                    />
-                </div>
-            )}
-            {showMonth && (
-                <div
-                    className={fr.cx(
-                        "fr-fieldset__element",
-                        "fr-fieldset__element--inline",
-                        "fr-fieldset__element--number",
-                    )}
-                >
-                    <NumericFormat
-                        key={`${id}-${iteration ?? ""}-month`}
-                        id={`${id}-${iteration ?? ""}-month`}
-                        inputMode="numeric"
-                        customInput={CustomInputDsfr}
-                        disabled={disabled}
-                        readOnly={readOnly}
-                        allowNegative={false}
-                        allowLeadingZeros
-                        isAllowed={({ value, floatValue }) =>
-                            floatValue === undefined ||
-                            (floatValue >= 0 && value.length <= 2 && value !== "00" && floatValue <= 12)
-                        }
-                        value={dateValues.month}
-                        onValueChange={values => onValueChange(values, "month")}
-                        dsfrProps={{
-                            label: "Mois",
-                            hintText: "Exemple: 07",
-                        }}
-                        {...(state === "error"
-                            ? { "aria-invalid": true, "aria-errormessage": errorMessageId }
-                            : {})}
-                    />
-                </div>
-            )}
 
-            <div
-                className={fr.cx(
-                    "fr-fieldset__element",
-                    "fr-fieldset__element--inline",
-                    "fr-fieldset__element--year",
-                )}
-            >
-                <NumericFormat
-                    key={`${id}-${iteration ?? ""}-year`}
-                    id={`${id}-${iteration ?? ""}-year`}
-                    inputMode="numeric"
-                    customInput={CustomInputDsfr}
-                    disabled={disabled}
-                    readOnly={readOnly}
-                    allowNegative={false}
-                    allowLeadingZeros
-                    isAllowed={({ value, floatValue }) =>
-                        floatValue === undefined ||
-                        (floatValue >= 0 && value.length <= 4 && value !== "0000" && floatValue <= 9999)
-                    }
-                    onValueChange={values => onValueChange(values, "year")}
-                    value={dateValues.year}
-                    dsfrProps={{
-                        label: "Année",
-                        hintText: "Exemple: 2024",
-                    }}
-                    {...(state === "error"
-                        ? { "aria-invalid": true, "aria-errormessage": errorMessageId }
-                        : {})}
-                />
+            <div className={fr.cx("fr-fieldset__element", "fr-fieldset__element--inline")}>
+                {/* Cannot give the className directly to MuiDatePicker since mui style overloads it. */}
+                <LocalizationProvider
+                    dateAdapter={AdapterDateFns}
+                    adapterLocale={frLocale}
+                    localeText={frFR.components.MuiLocalizationProvider.defaultProps.localeText}
+                >
+                    <MuiDatePicker
+                        value={selectedDate}
+                        onChange={handleDateChange}
+                        format={computeDisplayedFormat(dateFormat)}
+                        minDate={minDate}
+                        maxDate={maxDate}
+                        disabled={disabled}
+                        readOnly={readOnly}
+                        slotProps={{
+                            field: {
+                                clearable: true,
+                            },
+                        }}
+                    />
+                </LocalizationProvider>
             </div>
 
             <FiledsetError state={state} stateRelatedMessage={stateRelatedMessage} id={errorMessageId} />
@@ -221,21 +106,19 @@ export const Datepicker: LunaticSlotComponents["Datepicker"] = props => {
     );
 };
 
-/**
- * Check if the date provided by the user is valid (e.g. not 02/31)
- */
-function isDateValid(date: DateState) {
-    const { year, month, day } = date;
-    const yearNum = parseInt(year, 10);
-    const monthNum = parseInt(month, 10);
-    const dayNum = parseInt(day, 10);
+/** Compute displayed format for DatePicker */
+function computeDisplayedFormat(format: DateFormat) {
+    switch (format) {
+        case "YYYY-MM":
+            return "MM/yyyy";
+        case "YYYY":
+            return "yyyy";
+        default:
+            return "dd/MM/yyyy";
+    }
+}
 
-    const dateObj = new Date();
-    dateObj.setFullYear(yearNum, monthNum - 1, dayNum);
-
-    return (
-        dateObj.getFullYear() === yearNum &&
-        dateObj.getMonth() === monthNum - 1 &&
-        dateObj.getDate() === dayNum
-    );
+/** Compute date-fns format */
+function computeDateFnsFormat(format: DateFormat) {
+    return format.replace("YYYY", "yyyy").replace("DD", "dd");
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -156,6 +156,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.25.7", "@babel/runtime@^7.26.10":
+  version "7.27.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.0.tgz#fbee7cf97c709518ecc1f590984481d5460d4762"
+  integrity sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.26.9":
   version "7.26.9"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.26.9.tgz#4577ad3ddf43d194528cff4e1fa6b232fa609bb2"
@@ -970,10 +977,29 @@
     csstype "^3.1.3"
     prop-types "^15.8.1"
 
+"@mui/types@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.4.0.tgz#2304bab870721de1842c9ee0ff13fe8be6b8d0ed"
+  integrity sha512-TxJ4ezEeedWHBjOmLtxI203a9DII9l4k83RXmz1PYSAmnyEcK2PglTNmJGxswC/wM5cdl9ap2h8lnXvt2swAGQ==
+  dependencies:
+    "@babel/runtime" "^7.26.10"
+
 "@mui/types@~7.2.15":
   version "7.2.24"
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.24.tgz#5eff63129d9c29d80bbf2d2e561bd0690314dec2"
   integrity sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==
+
+"@mui/utils@^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-7.0.0.tgz#4e3411de9ac8f2892fdd97852260eb724731c0cd"
+  integrity sha512-oCRO9o08klpO13lZvPUt+ocmkyMlnAk76Eo8IIel6dcCBQQ0sTI5QNiSMzGC+JvusfPMGdvgIOVtHeyhRijJfQ==
+  dependencies:
+    "@babel/runtime" "^7.26.10"
+    "@mui/types" "^7.4.0"
+    "@types/prop-types" "^15.7.14"
+    clsx "^2.1.1"
+    prop-types "^15.8.1"
+    react-is "^19.0.0"
 
 "@mui/utils@^5.17.1":
   version "5.17.1"
@@ -986,6 +1012,27 @@
     clsx "^2.1.1"
     prop-types "^15.8.1"
     react-is "^19.0.0"
+
+"@mui/x-date-pickers@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-7.28.0.tgz#1daa089722b7b3b7458ad9af1ef39ae5ec9a9918"
+  integrity sha512-m1bfkZLOw3cMogeh6q92SjykVmLzfptnz3ZTgAlFKV7UBnVFuGUITvmwbgTZ1Mz3FmLVnGUQYUpZWw0ZnoghNA==
+  dependencies:
+    "@babel/runtime" "^7.25.7"
+    "@mui/utils" "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta"
+    "@mui/x-internals" "7.28.0"
+    "@types/react-transition-group" "^4.4.11"
+    clsx "^2.1.1"
+    prop-types "^15.8.1"
+    react-transition-group "^4.4.5"
+
+"@mui/x-internals@7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-internals/-/x-internals-7.28.0.tgz#b0a04f4c0f53f2f91d13a46f357f731b77c832c5"
+  integrity sha512-p4GEp/09bLDumktdIMiw+OF4p+pJOOjTG0VUvzNxjbHB9GxbBKoMcHrmyrURqoBnQpWIeFnN/QAoLMFSpfwQbw==
+  dependencies:
+    "@babel/runtime" "^7.25.7"
+    "@mui/utils" "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1940,7 +1987,7 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.2.tgz#5950e50960793055845e956c427fc2b0d70c5239"
   integrity sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
 
-"@types/prop-types@*", "@types/prop-types@^15.7.12":
+"@types/prop-types@*", "@types/prop-types@^15.7.12", "@types/prop-types@^15.7.14":
   version "15.7.14"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.14.tgz#1433419d73b2a7ebfc6918dcefd2ec0d5cd698f2"
   integrity sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==
@@ -1960,7 +2007,7 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.5.tgz#45f9f87398c5dcea085b715c58ddcf1faf65f716"
   integrity sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==
 
-"@types/react-transition-group@^4.4.10":
+"@types/react-transition-group@^4.4.10", "@types/react-transition-group@^4.4.11":
   version "4.4.12"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.12.tgz#b5d76568485b02a307238270bfe96cb51ee2a044"
   integrity sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==
@@ -2679,6 +2726,11 @@ date-fns@^2.27.0:
   integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
   dependencies:
     "@babel/runtime" "^7.21.0"
+
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
 dayjs@^1.8.12:
   version "1.11.13"


### PR DESCRIPTION
- for Datepicker, use a real datepicker (no matter the date format) instead of different fields for day/month/year.
- handle min & max dates


⚠️ The date format and all the labels are for french people. See if we want to handle both en/fr depending on navigator language ?